### PR TITLE
Fix compatibility with freenginx

### DIFF
--- a/ngx_http_response_body_module.c
+++ b/ngx_http_response_body_module.c
@@ -515,13 +515,18 @@ ngx_http_response_body_set_ctx(ngx_http_request_t *r)
 static ngx_msec_t
 ngx_http_response_body_request_time(ngx_http_request_t *r)
 {
-    ngx_time_t      *tp;
     ngx_msec_int_t   ms;
+
+#if (defined freenginx && nginx_version >= 1029000)
+    ms = (ngx_msec_int_t) (ngx_current_msec - r->start_time);
+#else
+    ngx_time_t      *tp;
 
     tp = ngx_timeofday();
 
     ms = (ngx_msec_int_t)
              ((tp->sec - r->start_sec) * 1000 + (tp->msec - r->start_msec));
+#endif
 
     return (ngx_msec_t) ngx_max(ms, 0);
 }


### PR DESCRIPTION
Commit freenginx/nginx@3329aa9 replaced two fields start_sec and start_msec in the ngx_http_request_t structure with one field start_time.